### PR TITLE
Add getStatementType function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.6.0] - 2021-03-22
+
+- Add `getStatementType` function
+
 ## [2.5.0] - 2021-03-18
 
 - Add support for ClickHouse `LIMIT <offset>, <number>` syntax

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ Returns array of statement strings. Used by `sql-limiter` internally but exposed
 
 Returns `sqlStatement` string with terminator removed. Used by `sql-limiter` internally but exposed for your convenience
 
+### `sqlLimiter.getStatementType( sqlStatement )`
+
+- `sqlStatement` - Single SQL statement text to get type keyword from.
+
+Returns `sqlStatement` type keyword in lower case. This will be the first keyword of the SQL query, sans `with` and `as` for CTE queries.
+
+```js
+console.log(sqlLimiter.getStatementType("SELECT * FROM ...")); // "select"
+console.log(
+  sqlLimiter.getStatementType("WITH foo AS (SELECT ...) INSERT INTO ... ")
+); // "insert"
+console.log(sqlLimiter.getStatementType("-- just a comment")); // undefined
+```
+
 ## Why
 
 `sql-limiter` was initially created to enforce SQL limits in [SQLPad](https://github.com/sqlpad/sqlpad).

--- a/src/index.js
+++ b/src/index.js
@@ -74,8 +74,30 @@ function removeTerminator(sqlStatement) {
   return statements[0];
 }
 
+/**
+ * Gets statement type keyword from statement string (select, update, delete, etc)
+ * Only a single statement allowed.
+ * Throws error if multiple statements are included
+ * @param {string} statementType
+ */
+function getStatementType(sqlStatement) {
+  if (typeof sqlStatement !== "string") {
+    throw new Error("sqlText must be string");
+  }
+  const statementObjects = getStatements(sqlStatement).filter(
+    (s) => s.toString().trim() !== ""
+  );
+
+  if (statementObjects.length > 1) {
+    throw new Error("Multiple statements detected");
+  }
+
+  return statementObjects[0].getStatementType();
+}
+
 module.exports = {
-  limit,
   getStatements: apiGetStatements,
+  getStatementType,
+  limit,
   removeTerminator,
 };

--- a/src/keywords.js
+++ b/src/keywords.js
@@ -253,6 +253,7 @@ module.exports = [
   "set",
   "setuser",
   "share",
+  "show",
   "shutdown",
   "size",
   "skip",

--- a/src/statement.js
+++ b/src/statement.js
@@ -11,6 +11,18 @@ class Statement {
     this.limitToken = null;
   }
 
+  /**
+   * Returns the statement type keyword in lower case.
+   * If CTE is detected, the first keywords after WITH and AS is returned
+   * @returns string
+   */
+  getStatementType() {
+    if (this.statementToken) {
+      return this.statementToken.value;
+    }
+    return undefined;
+  }
+
   appendToken(t) {
     const token = { ...t };
     token.parenLevel = this.parenLevel;

--- a/test/api-validations.js
+++ b/test/api-validations.js
@@ -64,3 +64,23 @@ describe("api: limit", function () {
     assert.equal(res, expected);
   });
 });
+
+describe("api: getStatementType", function () {
+  it("throws errors for multiple statements", function () {
+    assert.throws(() => sqlLimiter.getStatementType(`SELECT *; SELECT *;`));
+  });
+
+  it("returns correct keywords", function () {
+    assert.strictEqual(sqlLimiter.getStatementType("SELECT *"), "select");
+    assert.strictEqual(
+      sqlLimiter.getStatementType("-- select comment"),
+      undefined
+    );
+    assert.strictEqual(
+      sqlLimiter.getStatementType(
+        "WITH something AS (SELECT) INSERT INTO blah *"
+      ),
+      "insert"
+    );
+  });
+});


### PR DESCRIPTION
Adds `getStatementType` util function. This isn't required for primary API of sql-limiter, but it is useful and sql-limiter is figuring it out it.