### PR TITLE
Support injecting offset number (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ It ignores non-SELECT queries. It understands CTE statements. It understands str
 
 ## API
 
-### `sqlLimiter.limit( sqlText, limitStrategies, limitNumber )`
+### `sqlLimiter.limit( sqlText, limitStrategies, limitNumber, offsetNumber )`
 
 - `sqlText` - SQL text to enforce limits on. Multiple statements allowed. Only `SELECT` statements are targeted.
 - `limitStrategies` - Keyword or array of strategies used to restrict rows. Must be either `limit`, `first`, `top`, `fetch` for `FETCH NEXT`/`FETCH FIRST`.
 - `limitNumber` - Number of rows to allow. If number in statement is lower, it is untouched. If higher it is lowered to limit. If missing it is added.
+- `offsetNumber` - Number of rows to skip before beginning to return rows from the query. If number in statement is defined, it is untouched. If missing it is added.
 
 Returns `sqlText` with limits enforced.
 
@@ -49,6 +50,15 @@ const enforcedSql = sqlLimiter.limit(
   100
 );
 console.log(enforcedSql); // SELECT * FROM some_table fetch first 100 rows only;
+
+// When offset is defined
+const enforcedSql = sqlLimiter.limit(
+  `SELECT * FROM some_table;`,
+  "limit",
+  100,
+  10
+);
+console.log(enforcedSql); // SELECT * FROM some_table limit 100 offset 10;
 ```
 
 ### `sqlLimiter.getStatements( sqlText )`

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,15 @@ const getStatements = require("./get-statements");
  * @param {string} sqlText - sql text to limit
  * @param {Array<String>|String} limitStrategies -- First strategy value takes priority if no limit exists
  * @param {number} limitNumber -- number to enforce for limit keyword
+ * @param {number} [offsetNumber] -- offset number to enforce
  * @returns {string}
  */
-function limit(sqlText, limitStrategies, limitNumber) {
+function limit(
+  sqlText,
+  limitStrategies,
+  limitNumber,
+  offsetNumber,
+) {
   if (typeof sqlText !== "string") {
     throw new Error("sqlText must be string");
   }
@@ -36,6 +42,9 @@ function limit(sqlText, limitStrategies, limitNumber) {
   return getStatements(sqlText)
     .map((statement) => {
       statement.enforceLimit(strategies, limitNumber);
+      if (typeof offsetNumber === "number") {
+        statement.injectOffset(offsetNumber);
+      }
       return statement.toString();
     })
     .join("");

--- a/src/offset.js
+++ b/src/offset.js
@@ -1,0 +1,158 @@
+const createToken = require("./create-token");
+const {
+  findParenLevelToken,
+  nextNonCommentNonWhitespace,
+} = require("./token-utils");
+
+function has(tokens, startingIndex) {
+  const limitKeywordToken = findParenLevelToken(
+    tokens,
+    startingIndex,
+    (token) => token.type === "keyword" && token.value === "limit"
+  );
+
+  // Supported OFFSET syntaxes
+  // OFFSET <offset_number> { ROW | ROWS }
+  // LIMIT <offset_number>,<limit_number>
+  // LIMIT <limit_number> OFFSET <offset_number>
+
+  // OFFSET <offset_number> ROW/ROWS
+  if (!limitKeywordToken) {
+    const offsetKeywordToken = findParenLevelToken(
+      tokens,
+      startingIndex,
+      (token) => token.type === "keyword" && token.value === "offset"
+    );
+
+    if (!offsetKeywordToken) {
+      return null;
+    }
+
+    const offsetNumberToken = nextNonCommentNonWhitespace(
+      tokens,
+      offsetKeywordToken.index + 1
+    );
+
+    if (!offsetNumberToken) {
+      throw new Error("Unexpected end of statement");
+    }
+
+    if (offsetNumberToken.type !== "number") {
+      throw new Error(`Expected number got ${firstNumber.type}`);
+    }
+
+    const rowsToken = nextNonCommentNonWhitespace(
+      tokens,
+      offsetNumberToken.index + 1
+    );
+
+    if (!rowsToken) {
+      throw new Error("Expected ROW or ROWS after offset_number");
+    }
+
+    if (
+      rowsToken &&
+      (rowsToken.value === "row" || rowsToken.value === "rows")
+    ) {
+      return offsetNumberToken;
+    }
+  }
+
+  const firstNumber = nextNonCommentNonWhitespace(
+    tokens,
+    limitKeywordToken.index + 1
+  );
+
+  if (!firstNumber) {
+    throw new Error("Unexpected end of statement");
+  }
+
+  if (firstNumber.type !== "number") {
+    throw new Error(`Expected number got ${firstNumber.type}`);
+  }
+
+  const possibleCommaOrOffset = nextNonCommentNonWhitespace(
+    tokens,
+    firstNumber.index + 1
+  );
+
+  if (possibleCommaOrOffset) {
+    // LIMIT <offset_number>,<limit_number>
+    if (possibleCommaOrOffset.type === "comma") {
+      const secondNumber = nextNonCommentNonWhitespace(
+        tokens,
+        possibleCommaOrOffset.index + 1
+      );
+
+      if (!secondNumber) {
+        throw new Error("Unexpected end of statement");
+      }
+
+      if (secondNumber.type !== "number") {
+        throw new Error(`Expected number got ${secondNumber.type}`);
+      }
+
+      return firstNumber;
+    }
+    // LIMIT <limit_number> OFFSET <offset_number>
+    else if (
+      possibleCommaOrOffset.type === "keyword" &&
+      possibleCommaOrOffset.value === "offset"
+    ) {
+      const offsetNumber = nextNonCommentNonWhitespace(
+        tokens,
+        possibleCommaOrOffset.index + 1
+      );
+
+      if (!offsetNumber) {
+        throw new Error("Unexpected end of statement");
+      }
+
+      if (offsetNumber.type !== "number") {
+        throw new Error(`Expected number got ${offsetNumber.type}`);
+      }
+
+      return offsetNumber;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Adds offset to query that does not have it
+ * @param {*} queryTokens
+ * @param {*} statementKeywordIndex
+ * @param {*} offset
+ */
+function add(queryTokens, statementKeywordIndex, offset) {
+  // Find the limit token
+  const limitToken = findParenLevelToken(
+    queryTokens,
+    statementKeywordIndex,
+    (token) => token.type === "keyword" && token.value === "limit"
+  );
+
+  if (limitToken) {
+    // Insert OFFSET after the LIMIT clause
+    const nextToken = nextNonCommentNonWhitespace(
+      queryTokens,
+      limitToken.index + 2
+    );
+
+    const firstHalf = queryTokens.slice(0, nextToken.index + 1);
+    const secondHalf = queryTokens.slice(nextToken.index + 1);
+    return [
+      ...firstHalf,
+      createToken.singleSpace(),
+      createToken.keyword("offset"),
+      createToken.singleSpace(),
+      createToken.number(offset),
+      ...secondHalf,
+    ];
+  }
+  return;
+}
+
+exports.has = has;
+exports.add = add;

--- a/src/statement.js
+++ b/src/statement.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 const strategies = require("./strategies");
+const offset = require("./offset");
 
 class Statement {
   constructor() {
@@ -135,6 +136,24 @@ class Statement {
         statementToken.parenLevel,
         limitNumber
       );
+    }
+  }
+
+  /**
+   * @param {number} offsetNumber
+   */
+  injectOffset(offsetNumber) {
+    const { statementToken, tokens } = this;
+
+    if (statementToken && statementToken.value === "select") {
+      const offsetToken = offset.has(tokens, statementToken.index);
+      // If offset token exists already, return early
+      if (offsetToken) {
+        return;
+      }
+
+      // Offset clause was not found, so add it
+      this.tokens = offset.add(tokens, statementToken.index, offsetNumber);
     }
   }
 

--- a/test/offset.js
+++ b/test/offset.js
@@ -1,0 +1,105 @@
+const assert = require("assert");
+const sqlLimiter = require("../src/index");
+
+function test(sqlText, expected) {
+  const enforcedSql = sqlLimiter.limit(sqlText, "limit", 100, 10);
+  assert.equal(enforcedSql, expected);
+}
+
+describe("offset", () => {
+  it("basic limit not existing", () => {
+    test(
+      `SELECT * FROM something`,
+      "SELECT * FROM something limit 100 offset 10"
+    );
+  });
+
+  it("offset is not defined", () => {
+    test(
+      `SELECT * FROM something limit 100`,
+      "SELECT * FROM something limit 100 offset 10"
+    );
+  });
+
+  it("offset existing", () => {
+    test(
+      `SELECT i FROM t1 ORDER BY i ASC offset 10`,
+      "SELECT i FROM t1 ORDER BY i ASC limit 100 offset 10"
+    );
+  });
+
+  it("both limit and offset existing, over", () => {
+    test(
+      `SELECT * FROM something limit 10 offset 5`,
+      "SELECT * FROM something limit 10 offset 5"
+    );
+  });
+
+  it("handles cte", function () {
+    test(
+      `WITH cte AS (SELECT TOP 1 * FROM foo LIMIT 1) SELECT * FROM something limit 999 ;`,
+      "WITH cte AS (SELECT TOP 1 * FROM foo LIMIT 1) SELECT * FROM something limit 100 offset 10 ;"
+    );
+  });
+
+  it("throws for unexpected offset", function () {
+    assert.throws(() => test(`SELECT * FROM something limit 100 offset`));
+  });
+
+  it("offset,limit existing, over", function () {
+    test(
+      `SELECT * FROM something limit 5, 10`,
+      "SELECT * FROM something limit 5, 10"
+    );
+  });
+
+  it("handles offset,limit", function () {
+    test(
+      `SELECT * FROM something limit 0,999`,
+      `SELECT * FROM something limit 0,100`
+    );
+    test(
+      `SELECT * FROM something limit 0 , 999`,
+      `SELECT * FROM something limit 0 , 100`
+    );
+    test(
+      `SELECT * FROM something limit 0 , 9`,
+      `SELECT * FROM something limit 0 , 9`
+    );
+  });
+
+  it("handles trailing line comment", function () {
+    test(
+      `SELECT * FROM something -- comment`,
+      `SELECT * FROM something limit 100 offset 10 -- comment`
+    );
+  });
+
+  it("handles subquery", function () {
+    test(
+      `SELECT * FROM ( select something OFFSET 1 ROW ) ;`,
+      `SELECT * FROM ( select something OFFSET 1 ROW )  limit 100 offset 10;`
+    );
+  });
+
+  it("handles query wrapped in parens", function () {
+    test(
+      `(SELECT * FROM ( select something OFFSET 1 ROW ))`,
+      `(SELECT * FROM ( select something OFFSET 1 ROW ) limit 100 offset 10)`
+    );
+  });
+
+  it("handles FOR", function () {
+    test(
+      `SELECT * FROM something FOR UPDATE ;`,
+      `SELECT * FROM something limit 100 offset 10 FOR UPDATE ;`
+    );
+  });
+
+  it("ignores non-select", function () {
+    test(
+      `INSERT INTO foo SELECT * FROM something`,
+      `INSERT INTO foo SELECT * FROM something`
+    );
+  });
+});


### PR DESCRIPTION
* Add a `offsetNumber` parameter to the limit function which specifies
the number of offsets to be injected. If the query already defines
the offset value, this attribute will be ignored.
    
* Add offset module
    
* Extend the `Statement` class to add the `injectOffset` method.
    
* Add test
    
* Update README.md